### PR TITLE
Add S3 Bucket Policy to make public read access

### DIFF
--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -15,9 +15,9 @@ Globals:
       AllowMethods: "'GET,POST,OPTIONS'"
       AllowHeaders: "'content-type'"
       AllowOrigin: "'*'"
-#Parameters:
-#  PipelineRole:
-#    Type: String
+Parameters:
+  PipelineRole:
+    Type: String
 
 Resources:
   FrontendBucketPolicy:
@@ -33,16 +33,16 @@ Resources:
             Resource: !Sub
               - "arn:aws:s3:::${Bucket}/*"
               - Bucket: !Ref FrontendBucket
-#          - Effect: Allow
-#            Principal:
-#              AWS:
-#                - !Ref PipelineRole
-#            Action:
-#              - "s3:PutObject"
-#              - "s3:DeleteObject"
-#            Resource: !Sub
-#              - "arn:aws:s3:::${Bucket}/*"
-#              - Bucket: !Ref FrontendBucket
+          - Effect: Allow
+            Principal:
+              AWS:
+                - !Ref PipelineRole
+            Action:
+              - "s3:PutObject"
+              - "s3:DeleteObject"
+            Resource: !Sub
+              - "arn:aws:s3:::${Bucket}/*"
+              - Bucket: !Ref FrontendBucket
       Bucket: !Ref FrontendBucket
   CloudFrontOriginAccessIdentity:
     Type: AWS::CloudFront::CloudFrontOriginAccessIdentity


### PR DESCRIPTION
## Overview

Added S3 Bucket Policy to make S3 bucket public read access, so images are accessible through URL link. 



## Checklist

* [x] Conventional commits are followed.
* [x] `yarn verify` completed.
* [x] The new work has been locally tested and before and after screenshots are provided.
* [x] There are no package lock files (only `yarn` should be used) - frontend only.
* [x] The autogenerated `samconfig.toml`is left out - backend only.

## References
[
* ISSUE: https://github.com/CPSC319-2022/AmazonianPrime/issues/59
