### PR TITLE
[Backend] Modify admin orders endpoint GET Admin/Orders?userId&orderId

### DIFF
--- a/backend/functions/admin-get-orders/app.js
+++ b/backend/functions/admin-get-orders/app.js
@@ -21,8 +21,29 @@ exports.lambdaHandler = async (event, context) => {
   
   const offset = event.queryStringParameters.offset;
   const limit = event.queryStringParameters.limit;
+  const OrderID = event.queryStringParameters.orderId;
+  const UserID = event.queryStringParameters.userId;
 
-  var getOrdersQuery = `SELECT * FROM Orders LIMIT ${limit} OFFSET ${offset}`;
+  var options = [];
+
+  if (UserID != null && UserID !== undefined) {
+    options.push(`UserID = ${UserID}`);
+  }
+  if (OrderID != null && OrderID !== undefined) {
+    options.push(`OrderID = ${OrderID}`);
+  }
+
+  let whereClause;
+
+  if (options.length > 0) {
+    whereClause = options.reduce((a, b) => {
+      return a + ' AND ' + b;
+    });
+  }
+
+  var getOrdersQuery = `SELECT * FROM Orders ${
+    whereClause !== undefined ? `WHERE ${whereClause} ` : ''
+  }LIMIT ${limit} OFFSET ${offset}`;
 
   const Orders = await new Promise((resolve, reject) => {
     con.query(getOrdersQuery, function (err, res) {

--- a/backend/template.yaml
+++ b/backend/template.yaml
@@ -1177,6 +1177,12 @@ Resources:
               - method.request.querystring.limit:
                   Required: false
                   Caching: false
+              - method.request.querystring.orderId:
+                  Required: false
+                  Caching: false
+              - method.request.querystring.userId:
+                  Required: false
+                  Caching: false
       VpcConfig:
         SecurityGroupIds: [{ "Ref": "lambdaSecurityGroup" }]
         SubnetIds: [{ "Ref": "PrivateSubnet1" }, { "Ref": "PrivateSubnet2" }]


### PR DESCRIPTION
## Overview

Added two query params for userId and orderId in addition to offset and limit

## Checklist

* [ ] Conventional commits are followed.
* [ ] `yarn format` completed for BACKEND and FRONTEND.
* [ ] `yarn verify` completed.
* [ ] The new work has been locally tested and before and after screenshots are provided.
* [ ] There are no package lock files (only `yarn` should be used) - frontend only.
* [ ] The autogenerated `samconfig.toml`is left out - backend only.

## References

* ISSUE: [XXX](https://github.com/CPSC319-2022/AmazonianPrime/issues/XXX)
