### PR TITLE
feat(admin-get-orders): return total number of orders for search

### DIFF
--- a/backend/functions/admin-get-orders/app.js
+++ b/backend/functions/admin-get-orders/app.js
@@ -124,10 +124,26 @@ exports.lambdaHandler = async (event, context) => {
     order.Listings = listings;
   }
 
+  const getNumberOfOrders = `SELECT COUNT(*) FROM Orders ${
+    whereClause !== undefined ? `WHERE ${whereClause} ` : ''
+  };`;
+
+  const getOrdersCount = await new Promise((resolve, reject) => {
+    con.query(getNumberOfOrders, function (err, res) {
+      if (err) {
+        reject(err);
+      }
+      resolve(res);
+    });
+  });
+
   await dbConnection.disconnectDB(con);
   
   return {
     statusCode: 200,
-    body: JSON.stringify(Orders),
+    body: JSON.stringify({
+      TotalOrders: getOrdersCount[0]['COUNT(*)'],
+      Data: Orders,
+    }),
   };
 };


### PR DESCRIPTION
## Overview
admin-get-orders should return total number of orders for the orderId and userID provided

## Checklist

* [ ] Conventional commits are followed.
* [ ] `yarn format` completed for BACKEND and FRONTEND.
* [ ] `yarn verify` completed.
* [ ] The new work has been locally tested and before and after screenshots are provided.
* [ ] There are no package lock files (only `yarn` should be used) - frontend only.
* [ ] The autogenerated `samconfig.toml`is left out - backend only.

## References

* ISSUE: [XXX](https://github.com/CPSC319-2022/AmazonianPrime/issues/XXX)
