### PR TITLE
fix: orders show new orders, invalid credit card toast prompts users for 16-19 digits

### DIFF
--- a/frontend/src/components/cart/CartPage.tsx
+++ b/frontend/src/components/cart/CartPage.tsx
@@ -13,6 +13,7 @@ import Breadcrumbs from '../common/Breadcrumbs';
 import { useState } from 'react';
 import { useGetPaymentsQuery, useGetShippingAddressQuery } from '../../redux/api/user';
 import { useCheckoutMutation, useRetryCheckoutMutation } from '../../redux/api/shoppingCart';
+import { ordersApi } from '../../redux/api/orders';
 import { useDispatch } from 'react-redux';
 import {
   setCartLock,
@@ -93,6 +94,7 @@ function CartPage() {
   };
   const handleCheckoutSuccess = () => {
     dispatch(setSuccessMessage("We've got your order! Please check for a confirmation email."));
+    dispatch(ordersApi.util.invalidateTags(['Orders']));
     setDidCheckout(true);
     setTimeout(() => {
       setShowConfetti(true);

--- a/frontend/src/components/login/BuyerRegistration.tsx
+++ b/frontend/src/components/login/BuyerRegistration.tsx
@@ -114,7 +114,7 @@ function BuyerRegistration() {
 
     const regex = /^\d{16,19}$/; // Checks for 16-19 digit integer
     if (!regex.test(creditCardInput)) {
-      setOpenErrorToast('Please fill all required Payment fields!');
+      setOpenErrorToast('The credit card number must be between 16-19 digits!');
       return;
     }
 


### PR DESCRIPTION
## Overview

⚠️ _REPLACE WITH A BRIEF SUMMARY OF CHANGES BE SURE TO ADD SCREENSHOTS (UI/UX)_ ⚠️

| Before      | After       |
| ----------- | ----------- |
| Image1      | Image2      |
| Image3      | Image4      |

## Checklist

* [ ] Conventional commits are followed.
* [ ] `yarn format` completed for BACKEND and FRONTEND.
* [ ] `yarn verify` completed.
* [ ] The new work has been locally tested and before and after screenshots are provided.
* [ ] There are no package lock files (only `yarn` should be used) - frontend only.
* [ ] The autogenerated `samconfig.toml`is left out - backend only.

## References

* ISSUE: [XXX](https://github.com/CPSC319-2022/AmazonianPrime/issues/XXX)
